### PR TITLE
Removing MemoryConflictHandler

### DIFF
--- a/src/main/java/mclfloader/MCLFLoader.java
+++ b/src/main/java/mclfloader/MCLFLoader.java
@@ -9,7 +9,6 @@ import java.util.List;
 import ghidra.app.util.Option;
 import ghidra.app.util.bin.BinaryReader;
 import ghidra.app.util.bin.ByteProvider;
-import ghidra.app.util.importer.MemoryConflictHandler;
 import ghidra.app.util.importer.MessageLog;
 import ghidra.app.util.opinion.AbstractLibrarySupportLoader;
 import ghidra.app.util.opinion.LoadSpec;
@@ -44,7 +43,7 @@ public class MCLFLoader extends AbstractLibrarySupportLoader {
 
     @Override
     protected void load(ByteProvider provider, LoadSpec loadSpec, List<Option> options, Program program,
-            MemoryConflictHandler handler, TaskMonitor monitor, MessageLog log) throws CancelledException, IOException {
+            TaskMonitor monitor, MessageLog log) throws CancelledException, IOException {
         BinaryReader reader = new BinaryReader(provider, true);
         FlatProgramAPI api = new FlatProgramAPI(program, monitor);
         


### PR DESCRIPTION
New Ghidra 9.1 update removed the MemoryConflictHandler. Without the fix it was not possible to compile the MCLFLoader for the new version of Ghidra.